### PR TITLE
Fix API_Should_Not_HaveDependancyOnDomain Test

### DIFF
--- a/Mini-Twitter.Tests/Architecture/ArchitectureTests.cs
+++ b/Mini-Twitter.Tests/Architecture/ArchitectureTests.cs
@@ -85,8 +85,6 @@ namespace Mini_Twitter.Tests.Architecture
 
             // Act
             var result = Types.InAssembly(assembly)
-                .That()
-                .DoNotHaveNameEndingWith("Controller")
                 .ShouldNot()
                 .HaveDependencyOn(DomainNamespace)
                 .GetResult();


### PR DESCRIPTION
Test passed after changing the return type of API controllers to DTO's instead of domain entities.

Closes #27