### PR TITLE
Bug-Fix: IQueryable<T> being executed twice inside DistributedCacheExtensions.GetOrSetAsync

### DIFF
--- a/Mini-Twitter.API/Mini-Twitter.API.csproj
+++ b/Mini-Twitter.API/Mini-Twitter.API.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Mini_Twitter.API</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AutoMapper.AspNetCore.OData.EFCore" Version="4.0.2" />
     <PackageReference Include="Carter" Version="8.0.0" />
     <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.2.4" />

--- a/Mini-Twitter.API/Program.cs
+++ b/Mini-Twitter.API/Program.cs
@@ -7,7 +7,7 @@ builder.Services.AddControllers(options =>
     options.Filters.Add<LogActivityFilter>();
 }).AddOData(options =>
 {
-    options.AddRouteComponents("api/odata", new TwitterEntityDataModel().GetEntityDataModel()).Select().Filter().OrderBy().Expand().SetMaxTop(1000);
+    options.AddRouteComponents("api/odata", new TwitterEntityDataModel().GetEntityDataModel()).Select().Filter().OrderBy().Expand().SetMaxTop(1000).Count();
 });
 
 builder.Services.AddEndpointsApiExplorer();

--- a/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetDetails/GetTweetDetailsQueryHandler.cs
+++ b/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetDetails/GetTweetDetailsQueryHandler.cs
@@ -37,7 +37,7 @@ namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetDetails
                 : $"{Constants.TweetKey}-{queryString}";
 
             var tweetDto = await _cache
-                .GetOrSetAsync(key, async token =>
+                .GetOrSetAsync(key, async () =>
                 {
                     var tweet = await _repo
                         .GetAll(r => r.Id == request.Id && r.IsDeleted == false)

--- a/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetsList/GetTweetsListQueryHandler.cs
+++ b/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetsList/GetTweetsListQueryHandler.cs
@@ -1,7 +1,4 @@
-﻿using AutoMapper;
-using AutoMapper.AspNet.OData;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Caching.Distributed;
+﻿using Microsoft.AspNetCore.Http;
 using Mini_Twitter.Application.Extensions;
 
 namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetsList
@@ -33,7 +30,7 @@ namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetsList
                 ? Constants.TweetsKey
                 : $"{Constants.TweetsKey}-{queryString}";
 
-            var tweetsDto = await _cache.GetOrSetAsync(key, async token =>
+            var tweetsDto = await _cache.GetOrSetAsync(key, async () =>
             {
                 var tweets = await _repo
                 .GetAll(t => t.IsDeleted == false)


### PR DESCRIPTION
Passing the IQueryable<T> inside await cache.SetStringAsync(key, serlizedData, options, ct) caused it to be executed and then when returning it to the calling handler back to endpoint it executes again in there.

Closes #29