### PR TITLE
Feature: ICacheService and dynamic cache key on runtime.

### DIFF
--- a/Mini-Twitter.API/Controllers/TweetsController.cs
+++ b/Mini-Twitter.API/Controllers/TweetsController.cs
@@ -37,7 +37,11 @@
                     Id = key,
                     Options = options
                 });
-            return Ok(SingleResult.Create(tweet));
+
+            if (tweet is null)
+                return NotFound($"Tweet with Id: {key} was not found!");
+
+            return Ok(tweet);
         }
         #endregion
 

--- a/Mini-Twitter.API/Mini-Twitter.API.csproj
+++ b/Mini-Twitter.API/Mini-Twitter.API.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Mini_Twitter.API</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper.AspNetCore.OData.EFCore" Version="4.0.2" />
     <PackageReference Include="Carter" Version="8.0.0" />
     <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.2.4" />
@@ -15,7 +14,6 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mini-Twitter.Application\Mini-Twitter.Application.csproj" />

--- a/Mini-Twitter.Application/Abstractions/ICacheService.cs
+++ b/Mini-Twitter.Application/Abstractions/ICacheService.cs
@@ -1,0 +1,38 @@
+﻿namespace Mini_Twitter.Application.Abstractions
+{
+    public interface ICacheService
+    {
+        /// <summary>
+        /// Always project the IQueryable with ToList in order for this to work out.
+        /// If IQueryable is still used as T, Deserialize and Serialize will throw an exception.
+        /// </summary>
+        /// <typeparam name="T">Return type of the GetAsync.</typeparam>
+        /// <param name="key">Cache Key.</param>
+        /// <param name="fallbackFunction">Function to call back if cache don't contain cached item with the same key.</param>
+        /// <param name="options">Distributed CacheEntry Options, default value is 20s.</param>
+        /// <param name="cancellationToken">CancellationToken</param>
+        /// <returns></returns>
+        Task<T> GetAsync<T>(
+            string? key,
+            Func<Task<T>> fallbackFunction,
+            DistributedCacheEntryOptions options,
+            CancellationToken cancellationToken = default) where T : class;
+
+        /// <summary>
+        /// Deletes all set of keys from cache for a given prefix, 
+        /// works that way because we can have multiple cache keys for the same exact entity due to using different odata operations. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="prefix"></param>
+        /// <returns></returns>
+        Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete cached values for a given key.
+        /// You can use this directly if you have the exact key, if else better use RemoveByPrefixAsync.
+        /// </summary>
+        /// <param name="key">cache key of the items to be removed.</param>
+        /// <returns></returns>
+        Task RemoveAsync(string key, CancellationToken cancellationToken = default);
+    }
+}

--- a/Mini-Twitter.Application/Extensions/CacheOptions.cs
+++ b/Mini-Twitter.Application/Extensions/CacheOptions.cs
@@ -1,15 +1,7 @@
-﻿using Microsoft.Extensions.Caching.Distributed;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Mini_Twitter.Application.Extensions
+﻿namespace Mini_Twitter.Application.Extensions
 {
     public class CacheOptions
     {
-        public static DistributedCacheEntryOptions DefaultExpiration => new DistributedCacheEntryOptions() { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(20) };
-
+        public static DistributedCacheEntryOptions DefaultExpiration => new DistributedCacheEntryOptions() { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1) };
     }
 }

--- a/Mini-Twitter.Application/Extensions/DistributedCacheExtensions.cs
+++ b/Mini-Twitter.Application/Extensions/DistributedCacheExtensions.cs
@@ -4,6 +4,7 @@ namespace Mini_Twitter.Application.Extensions
 {
     public static class DistributedCacheExtensions
     {
+        [Obsolete("Use GetAsync from ICacheService instead!")]
         public static async Task<IQueryable<T>> GetOrSetAsync<T>(
             this IDistributedCache cache,
             string key,

--- a/Mini-Twitter.Application/Features/Tweets/Notifications/CacheInvalidationTweetHandler.cs
+++ b/Mini-Twitter.Application/Features/Tweets/Notifications/CacheInvalidationTweetHandler.cs
@@ -7,13 +7,13 @@
 
     {
         #region Fields and Properties
-        private readonly IDistributedCache _cache;
+        private readonly ICacheService _cacheService;
         #endregion
 
         #region Constructors
-        public CacheInvalidationTweetHandler(IDistributedCache cache)
+        public CacheInvalidationTweetHandler(ICacheService cacheService)
         {
-            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
         }
         #endregion
 
@@ -35,9 +35,11 @@
         #endregion
 
         #region Helper Methods
-        private async Task HandleInternal(string key)
+        private async Task HandleInternal(string prefix)
         {
-            await _cache.RemoveAsync(key);
+            // Dynamic way to remove all sets of cached keys for the same prefix
+            // fits well with odata operations
+            await _cacheService.RemoveByPrefixAsync(prefix);
         }
         #endregion
     }

--- a/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetDetails/GetTweetDetailsQuery.cs
+++ b/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetDetails/GetTweetDetailsQuery.cs
@@ -2,7 +2,7 @@
 
 namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetDetails
 {
-    public class GetTweetDetailsQuery : IRequest<IQueryable<TweetDto>>
+    public class GetTweetDetailsQuery : IRequest<TweetDto?>
     {
         public int Id { get; set; }
         public ODataQueryOptions<TweetDto> Options { get; set; }

--- a/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetDetails/GetTweetDetailsQueryHandler.cs
+++ b/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetDetails/GetTweetDetailsQueryHandler.cs
@@ -1,48 +1,36 @@
-﻿using AutoMapper;
-using AutoMapper.AspNet.OData;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Caching.Distributed;
-using Mini_Twitter.Application.Extensions;
-
-namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetDetails
+﻿namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetDetails
 {
-    public class GetTweetDetailsQueryHandler : IRequestHandler<GetTweetDetailsQuery, IQueryable<TweetDto>>
+    public class GetTweetDetailsQueryHandler : IRequestHandler<GetTweetDetailsQuery, TweetDto?>
     {
         #region Fields and Properties
         private readonly ITweetRepository _repo;
         private readonly IMapper _mapper;
-        private readonly IHttpContextAccessor _contextAccessor;
-        private readonly IDistributedCache _cache;
+        private readonly ICacheService _cacheService;
         #endregion
 
         #region Constructors
-        public GetTweetDetailsQueryHandler(ITweetRepository repo, IMapper mapper, IHttpContextAccessor contextAccessor, IDistributedCache cache)
+        public GetTweetDetailsQueryHandler(ITweetRepository repo, IMapper mapper, ICacheService cacheService)
         {
             _repo = repo ?? throw new ArgumentNullException(nameof(repo));
             _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
-            _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
-            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
         }
         #endregion
 
         #region Interface Implementation
-        public async Task<IQueryable<TweetDto>> Handle(GetTweetDetailsQuery request, CancellationToken cancellationToken)
+        public async Task<TweetDto?> Handle(GetTweetDetailsQuery request, CancellationToken cancellationToken)
         {
             var validator = new GetTweetDetailsQueryValidator();
             await validator.ValidateAndThrowAsync(request, cancellationToken);
 
-            var queryString = _contextAccessor.HttpContext!.Request.QueryString.ToString();
-            var key = string.IsNullOrEmpty(queryString)
-                ? Constants.TweetKey
-                : $"{Constants.TweetKey}-{queryString}";
-
-            var tweetDto = await _cache
-                .GetOrSetAsync(key, async () =>
+            var tweetDto = await _cacheService
+                .GetAsync(null, async () =>
                 {
                     var tweet = await _repo
                         .GetAll(r => r.Id == request.Id && r.IsDeleted == false)
                         .GetQueryAsync(_mapper, request.Options);
-                    return tweet;
+
+                    return tweet.FirstOrDefault()!;
                 }, CacheOptions.DefaultExpiration
                 , cancellationToken);
             return tweetDto;

--- a/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetsList/GetTweetsListQuery.cs
+++ b/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetsList/GetTweetsListQuery.cs
@@ -2,7 +2,7 @@
 
 namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetsList
 {
-    public class GetTweetsListQuery : IRequest<IQueryable<TweetDto>>
+    public class GetTweetsListQuery : IRequest<List<TweetDto>>
     {
         public ODataQueryOptions<TweetDto> Options { get; set; }
     }

--- a/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetsList/GetTweetsListQueryHandler.cs
+++ b/Mini-Twitter.Application/Features/Tweets/Queries/GetTweetsList/GetTweetsListQueryHandler.cs
@@ -1,43 +1,34 @@
-﻿using Microsoft.AspNetCore.Http;
-using Mini_Twitter.Application.Extensions;
-
-namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetsList
+﻿namespace Mini_Twitter.Application.Features.Tweets.Queries.GetTweetsList
 {
-    public class GetTweetsListQueryHandler : IRequestHandler<GetTweetsListQuery, IQueryable<TweetDto>>
+    public class GetTweetsListQueryHandler : IRequestHandler<GetTweetsListQuery, List<TweetDto>>
     {
         #region Fields and Properties
         private readonly ITweetRepository _repo;
         private readonly IMapper _mapper;
-        private readonly IHttpContextAccessor _contextAccessor;
-        private readonly IDistributedCache _cache;
+        private readonly ICacheService _cacheService;
         #endregion
 
         #region Constructors
-        public GetTweetsListQueryHandler(ITweetRepository repo, IMapper mapper, IHttpContextAccessor contextAccessor, IDistributedCache cache)
+        public GetTweetsListQueryHandler(ITweetRepository repo, IMapper mapper, ICacheService cacheService)
         {
             _repo = repo ?? throw new ArgumentNullException(nameof(repo));
             _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
-            _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
-            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
         }
         #endregion
 
         #region Interface Implementation
-        public async Task<IQueryable<TweetDto>> Handle(GetTweetsListQuery request, CancellationToken cancellationToken)
+        public async Task<List<TweetDto>> Handle(GetTweetsListQuery request, CancellationToken cancellationToken)
         {
-            var queryString = _contextAccessor.HttpContext!.Request.QueryString.ToString();
-            var key = string.IsNullOrEmpty(queryString)
-                ? Constants.TweetsKey
-                : $"{Constants.TweetsKey}-{queryString}";
-
-            var tweetsDto = await _cache.GetOrSetAsync(key, async () =>
+            var tweetsDto = await _cacheService.GetAsync(null, async () =>
             {
                 var tweets = await _repo
-                .GetAll(t => t.IsDeleted == false)
-                .GetQueryAsync(_mapper, request.Options);
-                return tweets;
+                        .GetAll(t => t.IsDeleted == false)
+                        .GetQueryAsync(_mapper, request.Options);
+                return tweets.ToList();
             }, CacheOptions.DefaultExpiration
             , cancellationToken);
+
             return tweetsDto;
         }
         #endregion

--- a/Mini-Twitter.Application/GlobalUsings.cs
+++ b/Mini-Twitter.Application/GlobalUsings.cs
@@ -15,3 +15,4 @@ global using AutoMapper.AspNet.OData;
 global using Microsoft.AspNetCore.OData.Query;
 global using Microsoft.Extensions.Caching.Distributed;
 global using Mini_Twitter.Application.Features.Tweets.Notifications;
+global using Mini_Twitter.Application.Extensions;

--- a/Mini-Twitter.Application/Models/Constants.cs
+++ b/Mini-Twitter.Application/Models/Constants.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Mini_Twitter.Application.Models
+﻿namespace Mini_Twitter.Application.Models
 {
     public class Constants
     {
         public const string TweetsKey = "tweets";
-        public const string TweetKey = "tweet";
+        public const string TweetKey = "tweet-";
     }
 }

--- a/Mini-Twitter.Infrastructure/InfrastructureServiceRegisteration.cs
+++ b/Mini-Twitter.Infrastructure/InfrastructureServiceRegisteration.cs
@@ -43,6 +43,7 @@
             services.AddScoped<IUserRepository, UserRepository>();
             services.AddScoped<ITimelineRepository, TimelineRepository>();
             services.AddScoped<IUserService, UserService>();
+            services.AddSingleton<ICacheService, CacheService>();
             #endregion
 
             return services;

--- a/Mini-Twitter.Infrastructure/Services/CacheService.cs
+++ b/Mini-Twitter.Infrastructure/Services/CacheService.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
+using Mini_Twitter.Application.Models.Dtos;
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace Mini_Twitter.Infrastructure.Services
+{
+    public class CacheService : ICacheService
+    {
+        #region Fields and Properties
+        private readonly IDistributedCache _cache;
+        private readonly IHttpContextAccessor _contextAccessor;
+        private static readonly ConcurrentDictionary<string, bool> CacheKeys = new();
+        #endregion
+
+        #region Constructors
+        public CacheService(IDistributedCache cache, IHttpContextAccessor contextAccessor)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
+        }
+        #endregion
+
+        #region Interface Implementation
+        public async Task<T> GetAsync<T>(
+            string? key,
+            Func<Task<T>> fallbackFunction,
+            DistributedCacheEntryOptions options,
+            CancellationToken cancellationToken = default) where T : class
+        {
+            // To-do: replace static key with dynamic one coming during runtime -> done
+            // To-do: make it work in a way if key is privided while calling method it will be used -> done
+            // if not just generate one at runtime
+            var cacheKey = key ?? GenerateCacheKey(typeof(T));
+
+            var cachedData = await _cache.GetStringAsync(cacheKey, cancellationToken);
+            if (!string.IsNullOrEmpty(cachedData))
+                return JsonSerializer.Deserialize<T>(cachedData)!;
+
+            var callbackData = await fallbackFunction();
+            await _cache.SetStringAsync(cacheKey, JsonSerializer.Serialize(callbackData), options, cancellationToken);
+            // Add the cachekey to the dict to handle delete events later on
+            CacheKeys.TryAdd(cacheKey, true);
+            return callbackData;
+        }
+
+        /// <summary>
+        /// Deletes all set of keys from cache for a given prefix, 
+        /// works that way because we can have multiple cache keys for the same exact entity due to using different odata operations. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="prefix"></param>
+        /// <returns></returns>
+        public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
+        {
+            IEnumerable<Task>? tasks = CacheKeys
+                .Keys
+                .Where(k => k.StartsWith(prefix))
+                .Select(k => RemoveAsync(k, cancellationToken));
+
+            await Task.WhenAll(tasks);
+        }
+
+        /// <summary>
+        /// Delete cached values for a given key.
+        /// You can use this directly if you have the exact key, if else better use RemoveByPrefixAsync.
+        /// </summary>
+        /// <param name="key">cache key of the items to be removed.</param>
+        /// <returns></returns>
+        public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+        {
+            await _cache.RemoveAsync(key, cancellationToken);
+            CacheKeys.TryRemove(key, out bool _);
+        }
+        #endregion
+
+        #region Helpers
+        /// <summary>
+        /// Generate cache key based on the type of the passed argument
+        /// </summary>
+        /// <param name="type">Type to generate cache key for.</param>
+        /// <returns>the generated key for the given type.</returns>
+        private string GenerateCacheKey(Type type)
+        {
+            var query = _contextAccessor.HttpContext!.Request.QueryString.Value;
+            string cacheKey;
+            switch (type)
+            {
+                case Type tweetType when tweetType == typeof(List<TweetDto>):
+                    cacheKey = string.IsNullOrEmpty(query)
+                        ? $"{Constants.TweetsKey}"
+                        : $"{Constants.TweetsKey}-{query}";
+                    break;
+
+                case Type tweetType when tweetType == typeof(TweetDto):
+                    {
+                        var routeParameters = _contextAccessor.HttpContext.Request.RouteValues;
+                        var key = routeParameters["key"];
+                        cacheKey = string.IsNullOrEmpty(query)
+                            ? $"{Constants.TweetKey}{key}"
+                            : $"{Constants.TweetKey}{query}";
+                    }
+                    break;
+
+                default:
+                    cacheKey = string.Empty;
+                    break;
+            }
+            return cacheKey;
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Abstracted IDistributedCache inside ICacheService and mark old GetOrSet as Obsolete.

Also, Introduce dynamic cache key on runtime (if no key is provided when calling GetAsync a dynamic key will be generated depending on the type of passing argument from the calling method to GetAsync).

Lastly, provided a way to remove cached items by prefix as we are using the QueryString from a given HttpContext in every key we store some values against to make sure every OData query is being cached in a proper way.

Closes #31