### PR TITLE
Enhance caching with lazy loading and concurrency control

### DIFF
--- a/Mini-Twitter.API/appsettings.json
+++ b/Mini-Twitter.API/appsettings.json
@@ -15,5 +15,8 @@
     "Audience": "Mini-Twitter.Website",
     "DurationInMinutes": 15000
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Cache": {
+    "UseLazyTasks": true
+  }
 }


### PR DESCRIPTION
Updated `appsettings.json` to include a `Cache` section with `UseLazyTasks` enabled. 
Introduced `CacheLocks` for better concurrency in `CacheService.cs`. 
Refactored `GetAsync<T>` to implement lazy loading of cache entries, ensuring single fallback function calls for concurrent requests. 
Improved error handling for `RedisConnectionException`. 
The `RemoveAsync` method remains unchanged. 
Overall, these changes improve performance and reduce unnecessary fallback function calls.